### PR TITLE
Scheduling

### DIFF
--- a/app/uk/gov/hmrc/digitalservicestax/aa_data/package.scala
+++ b/app/uk/gov/hmrc/digitalservicestax/aa_data/package.scala
@@ -21,7 +21,7 @@ import tag._
 import cats.implicits._
 import cats.kernel.Monoid
 import play.api.i18n.Messages
-import java.time.LocalDate
+import java.time.{LocalDate, LocalDateTime, temporal}
 
 package object data extends SimpleJson {
 
@@ -131,4 +131,16 @@ package object data extends SimpleJson {
   implicit val orderDate = new cats.Order[LocalDate] {
     def compare(x: LocalDate, y: LocalDate):Int = x.compareTo(y)
   }
+
+  implicit val orderDateTime = new cats.Order[LocalDateTime] {
+    def compare(x: LocalDateTime, y: LocalDateTime):Int = x.compareTo(y)
+  }
+
+  implicit class RichLocalDateTime(val value: LocalDateTime) extends AnyVal {
+    import scala.concurrent.duration._
+    def +(d: FiniteDuration): LocalDateTime = value.plusNanos(d.toNanos)
+    def -(d: FiniteDuration): LocalDateTime = value.minusNanos(d.toNanos)
+    def -(until: LocalDateTime): FiniteDuration = value.until(until, temporal.ChronoUnit.NANOS) nanos
+  }
+
 }

--- a/app/uk/gov/hmrc/digitalservicestax/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/digitalservicestax/config/AppConfig.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.digitalservicestax.config
 import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import scala.concurrent.duration._
 
 @Singleton
 class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig) {
@@ -32,6 +33,20 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
 
   val obligationStartDate: String = config.getOptional[String]("obligation-data.fromDate").getOrElse("2020-04-01")
 
-  val resilienceTickInterval: Long = config.getOptional[Long]("tick.interval").getOrElse(900)
+  object resilience { 
+
+    /** how frequently should the system check for jobs? */
+    val tickFrequency: FiniteDuration =
+      config.getOptional[FiniteDuration]("resilience.tick.frequency").getOrElse(10 seconds)
+
+    /** how long after the application starts up should we wait before we start checking for jobs? */
+    val tickDelay: FiniteDuration =
+      config.getOptional[FiniteDuration]("resilience.tick.delay").getOrElse(30 seconds)
+
+    /** maximum tasks per resilient function to process per tick */
+    val maxTasks: Int =
+      config.getOptional[Int]("resilience.max-tasks").getOrElse(1)
+
+  }
 
 }

--- a/app/uk/gov/hmrc/digitalservicestax/connectors/DesHelpers.scala
+++ b/app/uk/gov/hmrc/digitalservicestax/connectors/DesHelpers.scala
@@ -54,8 +54,11 @@ case class DesRetryRule(config: AppConfig) extends ltbs.resilientcalls.RetryRule
   def nextRetry(previous: List[(LocalDateTime, (Int,String))]): Option[LocalDateTime] = {
 
     // retry 5XX errors, give up on everything else
-    def isFatal(t: (Int,String)): Boolean =
-      t._1 < 500 || t._1 >= 600
+    def isFatal(t: (Int,String)): Boolean = {
+      val is5XX = t._1 >= 500 && t._1 < 600
+      val invalidRegime = t._1 == 400 && t._2.contains("INVALID_REGIME")
+      !is5XX && !invalidRegime
+    }
 
     // double the previous delay after each failed attempt
     // give up after 5 failed attempts (or a fatal error)

--- a/app/uk/gov/hmrc/digitalservicestax/controllers/RegistrationsController.scala
+++ b/app/uk/gov/hmrc/digitalservicestax/controllers/RegistrationsController.scala
@@ -122,7 +122,7 @@ class RegistrationsController @Inject()(
     resilienceProvider.apply(
       "send-registration",
       {submitRegistrationP _}.tupled,
-      DesRetryRule
+      DesRetryRule(appConfig)
     )
   }
 

--- a/app/uk/gov/hmrc/digitalservicestax/controllers/RegistrationsController.scala
+++ b/app/uk/gov/hmrc/digitalservicestax/controllers/RegistrationsController.scala
@@ -171,9 +171,4 @@ class RegistrationsController @Inject()(
       }
     }
   }
-
-  def tick() = Action.async {
-    resilienceProvider.tick() >> Future(Ok("done"))
-  }
-
 }

--- a/app/uk/gov/hmrc/digitalservicestax/resilience/AkkaProvider.scala
+++ b/app/uk/gov/hmrc/digitalservicestax/resilience/AkkaProvider.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ltbs.resilientcalls
+
+import scala.concurrent.{Future,duration}, duration.FiniteDuration
+import akka.actor._
+import uk.gov.hmrc.digitalservicestax.config.AppConfig
+
+trait AkkaScheduler {
+
+  val actorSystem: ActorSystem
+  def initialDelay: FiniteDuration
+  def frequency: FiniteDuration  
+
+  def tick(): Future[Unit]
+
+  private val Tick = "tick"
+  private class TickActor extends Actor {
+    def receive = { case Tick => tick() }
+  }
+
+  private val tickActor =
+    actorSystem.actorOf(Props(classOf[TickActor], this))
+
+  import actorSystem.dispatcher
+  val tickJob = actorSystem.scheduler.schedule(
+    initialDelay,
+    frequency,
+    tickActor,
+    Tick
+  )
+
+}

--- a/app/uk/gov/hmrc/digitalservicestax/resilience/DSTProvider.scala
+++ b/app/uk/gov/hmrc/digitalservicestax/resilience/DSTProvider.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ltbs.resilientcalls
+
+import akka.actor.ActorSystem
+import javax.inject._
+import play.modules.reactivemongo._
+import scala.concurrent._
+import uk.gov.hmrc.digitalservicestax.config.AppConfig
+import uk.gov.hmrc.http._
+
+@Singleton
+class DstMongoProvider @Inject()(
+  mongo: ReactiveMongoApi,
+  val actorSystem: ActorSystem,
+  val appConfig: AppConfig,
+  implicit val ec: ExecutionContext  
+) extends MongoProvider[(Int, String)](mongo,
+  {
+    case Upstream4xxResponse(msg, code, _, _) => (code, msg)
+    case Upstream5xxResponse(msg, code, _) => (code, msg)
+    case e => (-1, e.getLocalizedMessage)
+  }
+) with AkkaScheduler {
+  override val maxTasks: Int = appConfig.resilience.maxTasks
+  def initialDelay = appConfig.resilience.tickDelay
+  def frequency = appConfig.resilience.tickFrequency
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -7,8 +7,6 @@ GET  /lookup-company/:utr/:postcode                       uk.gov.hmrc.digitalser
 POST /registration                                        uk.gov.hmrc.digitalservicestax.controllers.RegistrationsController.submitRegistration()
 GET  /registration                                        uk.gov.hmrc.digitalservicestax.controllers.RegistrationsController.lookupRegistration()
 
-GET  /registration/tick                                   uk.gov.hmrc.digitalservicestax.controllers.RegistrationsController.tick()                            
-
 # the readme says this should be a GET, but we're receiving a POST...
 POST /tax-enrolment-callback/:subscriptionId              uk.gov.hmrc.digitalservicestax.controllers.TaxEnrolmentCallbackController.callback(subscriptionId)
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -207,4 +207,6 @@ resilience {
 
   # maximum tasks per resilient function to process per tick
   max-tasks = 1
+
+  des-enabled-on = 2020-04-06
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -195,3 +195,16 @@ microservice {
 }
 
 log.register-response=true
+
+resilience {
+  tick {
+    # how long after the application starts up should we wait before we start checking for jobs?
+    delay = 30 seconds
+
+    # how frequently should the system check for jobs?
+    interval = 10 seconds
+  }
+
+  # maximum tasks per resilient function to process per tick
+  max-tasks = 1
+}


### PR DESCRIPTION
This change removes the need for the 'tick' method call on the backend and instead uses a periodic akka task to check for pending jobs.